### PR TITLE
Delete recipe feature with TDD

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -67,3 +67,11 @@ $navbar-default-bg: #432c1e;
 .colormatch a {
   color: #652D0E;
 }
+
+.recipe-actions {
+  padding-top: 5px;
+  a {
+    color: #fff;
+  }
+}
+

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -35,6 +35,12 @@ class RecipesController < ApplicationController
       render 'edit'
     end
   end
+
+  def destroy
+    Recipe.find(params[:id]).destroy
+    flash[:success] = "Recipe deleted successfully"
+    redirect_to recipes_path
+  end
   
 
   private

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -22,4 +22,8 @@
         </div>
     </p>
   </div>
+  <div class="recipe-actions">
+    <%= link_to "Edit this recipe", edit_recipe_path(@recipe), class: "btn btn-xs btn-warning" %>
+    <%= link_to "Delete this recipe", recipe_path(@recipe), method: :delete, data: { confirm: "Are you sure you want to delete this recipe?"}, class: "btn btn-xs btn-danger" %>
+  </div>
 </div>

--- a/test/integration/recipes_delete_test.rb
+++ b/test/integration/recipes_delete_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class RecipesDeleteTest < ActionDispatch::IntegrationTest
+  def setup
+    @chef = Chef.create!(chefname: "Nithin", email: "nithin@example.com")
+    @recipe = Recipe.create(name: "Jamun", description: "Add jamun mix and water", chef: @chef)
+  end
+
+  test "successfully delete a recipe" do 
+    get recipe_path(@recipe)
+    assert_template 'recipes/show'    
+    assert_select 'a[href=?]', recipe_path(@recipe), text: "Delete this recipe"
+    assert_difference 'Recipe.count', -1 do
+      delete recipe_path(@recipe)
+    end
+    assert_redirected_to recipes_path
+    assert_not flash.empty?
+  end
+end

--- a/test/integration/recipes_test.rb
+++ b/test/integration/recipes_test.rb
@@ -26,6 +26,8 @@ class RecipesTest < ActionDispatch::IntegrationTest
     assert_match @recipe.name, response.body
     assert_match @recipe.description, response.body
     assert_match @chef.chefname, response.body
+    assert_select "a[href=?]", edit_recipe_path(@recipe), text: "Edit this recipe"
+    assert_select "a[href=?]", recipe_path(@recipe), text: "Delete this recipe"
   end
 
   test "create new valid recipe" do


### PR DESCRIPTION
Link to edit and delete the recipe from the show page and accordingly handled the check at the recipes_test show action.
Added the ability to delete a recipe from the browser along with the necessary integration test.
More details on:
https://docs.google.com/document/d/1H8NjDAuZuSHs4gZ9nry4uAUzNZDJSxE7kcSrOr7DpTk/edit